### PR TITLE
Refactor: Removed duplicate code and create direct buffer

### DIFF
--- a/src/Parquet/Encodings/DeltaBinaryPackedEncoder.Encode.Variations.tt
+++ b/src/Parquet/Encodings/DeltaBinaryPackedEncoder.Encode.Variations.tt
@@ -12,8 +12,6 @@
     //https://github.com/xitongsys/parquet-go/blob/62cf52a8dad4f8b729e6c38809f091cd134c3749/encoding/encodingwrite.go#L287
 
     static partial class DeltaBinaryPackedEncoder {
-         private static readonly ArrayPool<byte> BytePool = ArrayPool<byte>.Shared;
-
 <# foreach(string nt in types) { #>
         private static void Encode(ReadOnlySpan<<#= nt#>> data, Stream destination) {
                     
@@ -50,39 +48,32 @@
                     while(blockBufCounter < blockSize) {
                         rentedBlockBuf[blockBufCounter++] = minDelta;
                     }
-                    byte[] rentedBitWidths = BytePool.Rent(numMiniBlocksInBlock);
 
-                    try {
-                        for(int j = 0; j < numMiniBlocksInBlock; j++) {
-                            <#= nt#> maxValue = 0;
-                            for(int k = j * numValuesInMiniBlock; k < (j + 1) * numValuesInMiniBlock; k++) {
-                                rentedBlockBuf[(int)k] = rentedBlockBuf[(int)k] - minDelta;
-                                if(rentedBlockBuf[(int)k] > maxValue) {
-                                    maxValue = rentedBlockBuf[(int)k];
-                                }
-                            }
-                            rentedBitWidths[j] = (byte)(maxValue.GetBitWidth());
-                        }
-
-                        WriteZigZagVarLong(destination, minDelta);
-                        destination.Write(rentedBitWidths, 0, numMiniBlocksInBlock);
-
-                        for(int j = 0; j < numMiniBlocksInBlock; j++) {
-                            int miniBlockStart = j * numValuesInMiniBlock;
-                            for(int k = miniBlockStart; k < (j + 1) * numValuesInMiniBlock; k += 8) {
-                                byte[] rentedMiniBlock = BytePool.Rent(rentedBitWidths[j]);
-                                try {
-                                    int end = Math.Min(8, blockSize - k);
-                                    BitPackedEncoder.Encode8ValuesLE(rentedBlockBuf.AsSpan(k, end), rentedMiniBlock, rentedBitWidths[j]);
-                                    destination.Write(rentedMiniBlock, 0, rentedBitWidths[j]);
-                                } finally {
-                                    BytePool.Return(rentedMiniBlock);
-                                }
+                    byte[] rentedBitWidths = new byte[numMiniBlocksInBlock];
+                    for(int j = 0; j < numMiniBlocksInBlock; j++) {
+                        <#= nt#> maxValue = 0;
+                        for(int k = j * numValuesInMiniBlock; k < (j + 1) * numValuesInMiniBlock; k++) {
+                            rentedBlockBuf[(int)k] = rentedBlockBuf[(int)k] - minDelta;
+                            if(rentedBlockBuf[(int)k] > maxValue) {
+                                maxValue = rentedBlockBuf[(int)k];
                             }
                         }
-                    } finally {
-                        BytePool.Return(rentedBitWidths);
+                        rentedBitWidths[j] = (byte)(maxValue.GetBitWidth());
                     }
+
+                    WriteZigZagVarLong(destination, minDelta);
+                    destination.Write(rentedBitWidths, 0, numMiniBlocksInBlock);
+
+                    for(int j = 0; j < numMiniBlocksInBlock; j++) {
+                        int miniBlockStart = j * numValuesInMiniBlock;
+                        for(int k = miniBlockStart; k < (j + 1) * numValuesInMiniBlock; k += 8) {
+                            byte[] rentedMiniBlock = new byte[rentedBitWidths[j]];
+                            int end = Math.Min(8, blockSize - k);
+                            BitPackedEncoder.Encode8ValuesLE(rentedBlockBuf.AsSpan(k, end), rentedMiniBlock, rentedBitWidths[j]);
+                            destination.Write(rentedMiniBlock, 0, rentedBitWidths[j]);
+                        }
+                    }
+                   
                 } finally {
                     <#= nt#>Pool.Return(rentedBlockBuf);
                 }

--- a/src/Parquet/Encodings/DeltaBinaryPackedEncoder.cs
+++ b/src/Parquet/Encodings/DeltaBinaryPackedEncoder.cs
@@ -67,7 +67,7 @@ namespace Parquet.Encodings {
         }
 
         private static void WriteUnsignedVarInt(Stream destination, int value) {
-            WriteUnsignedVarInt(destination, (uint)value);
+            WriteUnsignedVarLong(destination, (uint)value);
         }
 
         private static void WriteZigZagVarLong(Stream destination, long value) {
@@ -76,19 +76,6 @@ namespace Parquet.Encodings {
         }
         private static void WriteUnsignedVarLong(Stream stream, ulong value) {
             byte[] buffer = new byte[10];
-            int index = 0;
-
-            while(value >= 0x80) {
-                buffer[index++] = (byte)(value | 0x80);
-                value >>= 7;
-            }
-
-            buffer[index++] = (byte)value;
-            stream.Write(buffer, 0, index);
-        }
-
-        private static void WriteUnsignedVarInt(Stream stream, uint value) {
-            byte[] buffer = new byte[5];
             int index = 0;
 
             while(value >= 0x80) {


### PR DESCRIPTION
- used WriteUnsignedVarLong inside WriteUnsignedVarInt
- removed arraypool for smaller buffer
 
https://github.com/aloneguid/parquet-dotnet/pull/382


